### PR TITLE
可以自定义设置ambiguityForest对象，覆盖默认的全局静态分词纠错的词库。

### DIFF
--- a/src/main/java/org/ansj/splitWord/Analysis.java
+++ b/src/main/java/org/ansj/splitWord/Analysis.java
@@ -1,6 +1,7 @@
 package org.ansj.splitWord;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -234,6 +235,16 @@ public abstract class Analysis {
 	public void resetContent(AnsjReader br) {
 		this.offe = 0;
 		this.br = br;
+	}
+	
+	public void resetContent(Reader reader) {
+		this.offe = 0;
+		this.br = new AnsjReader(reader);
+	}
+	
+	public void resetContent(Reader reader,int buffer) {
+		this.offe = 0;
+		this.br = new AnsjReader(reader,buffer);
 	}
 	
 	public Forest getAmbiguityForest() {


### PR DESCRIPTION
这样就可以读取数据库系统或者其他系统中设置自定义词库。
也可在在系统不重启的情况下，设置分词纠错词库并生效。
