### PR TITLE
解决使用自定义词典时的bug

### DIFF
--- a/src/main/java/org/ansj/splitWord/impl/GetWordsImpl.java
+++ b/src/main/java/org/ansj/splitWord/impl/GetWordsImpl.java
@@ -66,8 +66,13 @@ public class GetWordsImpl implements GetWords {
 					tempBaseValue = baseValue;
 					return str;
 				} else {
-					i = start;
-					start++;
+					// i = start;
+					// start++;
+					// end = 0;
+					// baseValue = 0;
+					// break;
+					start=i;
+					i--;
 					end = 0;
 					baseValue = 0;
 					break;


### PR DESCRIPTION
比如语句中有“苹果醋”词语，而且自定义词典中有“苹果”“苹果醋”“果醋”“苹果果醋”，就会报索引异常，“Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 13
	at org.ansj.util.Graph.getMaxTerm(Graph.java:164)”
自带core.dic中有“苹果”词语+词性，“苹”字core.dic中只有词没有词性，所有在先使用core.dic切词时会把“苹果”一个词，然后，下个元素是“果”字，结果就是“苹果”、“果”、“醋”（在Analysis.java193、194行插入terms，gp.addTerm(new Term(str, gwi.offe, gwi.getItem()));），这样再通过自定义词典处理之后，会组成“苹果果醋”这样的字符串，长度就多了1，在Graph.getMaxTerm时就报了异常。所以我想就是当cord.dic匹配“苹果”之后，再查看“苹果醋”不存在core.dic之后，就把start改为i,把“苹”字后边的元素跳过去，直接处理“醋”字。

我的测试程序：
	public static void main(String[] args) {
		Forest forest = new Forest();
	    UserDefineLibrary.loadLibrary(forest,"E:/base.dic");
	    UserDefineLibrary.FOREST=forest;
	    Result re = DicAnalysis.parse("发扬光大对方地方看苹果醋");
	    System.out.println(re);
	}