### PR TITLE
解决使用自定义词库分词bug

### DIFF
--- a/src/main/java/org/ansj/splitWord/impl/GetWordsImpl.java
+++ b/src/main/java/org/ansj/splitWord/impl/GetWordsImpl.java
@@ -66,15 +66,18 @@ public class GetWordsImpl implements GetWords {
 					tempBaseValue = baseValue;
 					return str;
 				} else {
-					// i = start;
-					// start++;
-					// end = 0;
-					// baseValue = 0;
-					// break;
-					start=i;
-					i--;
-					end = 0;
-					baseValue = 0;
+					int startCharStatus = DATDictionary.getItem(chars[start]).getStatus();
+					if (startCharStatus == 1) { //如果start的词的status为1，则将start设为i；否则start加1
+						start=i;
+						i--;
+						end = 0;
+						baseValue = 0;
+					} else {
+						i = start;
+						start++;
+						end = 0;
+						baseValue = 0;
+					}
 					break;
 				}
 			case 2:
@@ -92,11 +95,6 @@ public class GetWordsImpl implements GetWords {
 				return DATDictionary.getItem(tempBaseValue).getName();
 			}
 
-		}
-		if (start++ != i) {
-			i = start;
-			baseValue = 0;
-			return allWords();
 		}
 		end = 0;
 		baseValue = 0;


### PR DESCRIPTION
上一次做过一次修改，但是修复之后使用还是有问题，这次又处理了一下，进行了些数据测试，暂时没有发现问题。我上次的处理逻辑适合的情况为start的字的状态为1（DATDictionary.getItem(chars[start]).getStatus();）其他情况还是走原逻辑。if (start++ != i) {····}需要去掉。