### PR TITLE
修复 pos increment 问题

### DIFF
--- a/plugin/ansj_lucene6_plugin/src/main/java/org/ansj/lucene/util/AnsjTokenizer.java
+++ b/plugin/ansj_lucene6_plugin/src/main/java/org/ansj/lucene/util/AnsjTokenizer.java
@@ -55,6 +55,7 @@ public final class AnsjTokenizer extends Tokenizer {
 			return false;
 		}
 
+		position = 0;
 		if (obj instanceof Term) {
 			clearAttributes();
 			Term term = (Term) obj;


### PR DESCRIPTION
对 #431 的补充
额，其实我是这样子改的，这样可以修复position属性斐波拉契增长的问题，否则当token数达到65536的时候，position值已经溢出int范围了。
posincrement是position属性的增加量。按照lucene标准的说法，正常情况下应该都是1的，同义词可以设置为0、中间有token被过滤掉的时候可以额外增加这个值。