### PR TITLE
use relative path in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ jdk:
   - openjdk8
 
 before_install:
-  - cd /home/travis/build/NLPchina/
   - sudo git clone https://github.com/NLPchina/nlp-lang.git
   - sudo chmod -R 777 nlp-lang
   - cd ./nlp-lang
   - mvn clean compile package install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true
-  - cd /home/travis/build/NLPchina/ansj_seg
+  - cd ..
 
 install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true


### PR DESCRIPTION
Travis CI的默认工作路径是`/home/travis/build/{owner}/`, 如ansj_seg项目的owner指的是组织名`NLPchina`，如果在Travis CI中指定了绝对路径`/home/travis/build/NLPchina/`，那么当fork仓库配置了自己的Travis CI，则CI会失败，因为fork用户的Travis默认工作路径并不是`/home/travis/build/NLPchina/`，例如我的fork仓库执行Travis的时候，工作路径是`/home/travis/build/Alanscut/`，因此就会报错：不存在路径`/home/travis/build/NLPchina/`

因此如果直接使用相对路径的话，在其他开发者的fork仓库中CI也会执行成功。